### PR TITLE
fix(types): export Renderers and Command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-export type { Command } from './command';
-export type { Renderers } from './render-help';
-
 export { cli } from './cli';
-export { command } from './command';
+export { command, type Command } from './command';
+export type { Renderers } from './render-help';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,5 @@
+export type { Command } from './command';
+export type { Renderers } from './render-help';
+
 export { cli } from './cli';
 export { command } from './command';


### PR DESCRIPTION
Resolves https://github.com/privatenumber/cleye/issues/10

Playing a bit more with the types, it seems like exposing both `Renderers` and `Command` solves the issue.

This is a discussion on TypeScript's Discord with an expert:

<img width="1492" alt="image" src="https://user-images.githubusercontent.com/1443499/171945534-3e97eaed-3bf8-4c38-a91d-d206156803ac.png">
