### PR TITLE
feat: parent flags in command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -132,7 +132,7 @@ function cliBase<
 	callback: CallbackFunction<ParseArgv<Options, Parameters>> | undefined,
 	argv: string[],
 ) {
-	const flags = { ...options.flags };
+	const flags = { ...options.flags, ...options.parent?.flags };
 	const isVersionEnabled = options.version;
 
 	// Expected to work even if flag is overwritten; add tests
@@ -337,11 +337,8 @@ function cli<
 		[KeyA in keyof Commands]: (
 			Commands[KeyA] extends Command
 				? (
-					{
-						[
-							KeyB in keyof Commands[KeyA][typeof parsedType]
-						]: Commands[KeyA][typeof parsedType][KeyB];
-					}
+                                        Commands[KeyA][typeof parsedType] &
+                                        { flags: ParseArgv<Options, Parameters, undefined>['flags'] }
 				) : never
 		);
 	}[number]

--- a/tests/specs/command.ts
+++ b/tests/specs/command.ts
@@ -243,7 +243,7 @@ export default testSuite(({ describe }) => {
 						expect<number | undefined>(parsed.flags.flagC);
 						callback();
 					},
-					['--flagA', 'valueA', '--flagB', '123'],
+					['--flagC', '456', '--flagA', 'valueA', '--flagB', '123'],
 				);
 
 				if (argv.command === undefined) {
@@ -254,9 +254,7 @@ export default testSuite(({ describe }) => {
 
 				if (argv.command === 'commandA') {
 					expect<string | undefined>(argv.flags.flagA);
-
-					// @ts-expect-error non exixtent property
-					expect(argv.flags.flagC);
+					expect<number | undefined>(argv.flags.flagC);
 				}
 
 				if (argv.command === 'commandB') {


### PR DESCRIPTION
# Summary
An attempt to resolve #20

I don't think it works in the order specified:
```
git --no-pager log --pretty=oneline
```
since the command has to precede flags. But it should work fine with something like this, which is similar enough?
```
git log --no-pager --pretty=oneline
```
The command "log" comes before the parent flag "no-pager". I think I prefer it like this since it seems unusual to pass flags before a command even if they're technically associated with the parent, IMO.

# Description
- Simplified the parsing of the command array, and union-ed parent flags with the parsed command's flags.
- `cliBase` now includes its parent flags (if any) as well as its own.
- Was able to remove a ts-ignore that previously couldn't see parent flags.