### PR TITLE
Fix: Preserve acronym casing (ID, URL, API, JSON, ...) issue!

### DIFF
--- a/src/utils/convert-case.ts
+++ b/src/utils/convert-case.ts
@@ -1,3 +1,3 @@
 export const camelCase = (word: string) => word.replaceAll(/[\W_]([a-z\d])?/gi, (_, c) => (c ? c.toUpperCase() : ''));
 
-export const kebabCase = (word: string) => word.replaceAll(/\B([a-z])([A-Z])/g, '$1-$2').replaceAll(/\B([A-Z])([a-z])/g, '-$1$2').toLowerCase();
+export const kebabCase = (word: string) => word.replaceAll(/([a-z])([A-Z])/g, '$1-$2').replaceAll(/\B([A-Z])([a-z])/g, '-$1$2').toLowerCase();

--- a/src/utils/convert-case.ts
+++ b/src/utils/convert-case.ts
@@ -1,3 +1,3 @@
 export const camelCase = (word: string) => word.replaceAll(/[\W_]([a-z\d])?/gi, (_, c) => (c ? c.toUpperCase() : ''));
 
-export const kebabCase	= (word: string) => word.replaceAll(/\B([A-Z])/g, '-$1').toLowerCase();
+export const kebabCase = (word: string) => word.replaceAll(/\B([a-z])([A-Z])/g, '$1-$2').replaceAll(/\B([A-Z])([a-z])/g, '-$1$2').toLowerCase();

--- a/tests/specs/edge-cases.ts
+++ b/tests/specs/edge-cases.ts
@@ -114,8 +114,9 @@ export default testSuite(({ describe }) => {
 			});
 
 			test('multiple uppercase letters', () => {
-				expect(kebabCase('getHTTPResponse')).toBe('get-h-t-t-p-response');
-				expect(kebabCase('XMLParser')).toBe('x-m-l-parser');
+				expect(kebabCase('getHTTPResponse')).toBe('get-http-response');
+				expect(kebabCase('XMLParser')).toBe('xml-parser');
+				expect(kebabCase('apiURL')).toBe('api-url');
 			});
 
 			test('already kebab-case input', () => {
@@ -133,7 +134,7 @@ export default testSuite(({ describe }) => {
 			});
 
 			test('all uppercase', () => {
-				expect(kebabCase('ABC')).toBe('a-b-c');
+				expect(kebabCase('ABC')).toBe('abc');
 			});
 
 			test('empty string', () => {

--- a/tests/specs/edge-cases.ts
+++ b/tests/specs/edge-cases.ts
@@ -117,6 +117,7 @@ export default testSuite(({ describe }) => {
 				expect(kebabCase('getHTTPResponse')).toBe('get-http-response');
 				expect(kebabCase('XMLParser')).toBe('xml-parser');
 				expect(kebabCase('apiURL')).toBe('api-url');
+				expect(kebabCase('xAPIKeyWithJSONResponse')).toBe("x-api-key-with-json-response");
 			});
 
 			test('already kebab-case input', () => {


### PR DESCRIPTION
Updated the code to support preserving acronym casing.