### PR TITLE
feat: allow spaces in CLI name for help output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -502,7 +502,7 @@ function cli<
 		throw new Error('Options is required');
 	}
 
-	if ('name' in options && (!options.name || !isValidScriptName(options.name))) {
+	if ('name' in options && (!options.name || options.name !== options.name.trim())) {
 		throw new Error(`Invalid script name: ${stringify(options.name)}`);
 	}
 

--- a/tests/specs/cli.ts
+++ b/tests/specs/cli.ts
@@ -19,18 +19,25 @@ describe('cli', () => {
 			}).toThrow('Invalid script name: ""');
 		});
 
-		test('invalid name format', () => {
+		test('name with leading space', () => {
 			expect(() => {
 				cli({
-					name: 'a b',
+					name: ' a',
 				});
-			}).toThrow('Invalid script name: "a b"');
+			}).toThrow('Invalid script name: " a"');
 		});
 
-		test('allowed name format', () => {
-			cli({
-				name: 'a.b_',
-			});
+		test('name with trailing space', () => {
+			expect(() => {
+				cli({
+					name: 'a ',
+				});
+			}).toThrow('Invalid script name: "a "');
+		});
+
+		test('allowed name formats', () => {
+			cli({ name: 'a.b_' });
+			cli({ name: 'multiple parent commands' });
 		});
 	});
 


### PR DESCRIPTION
Hello @privatenumber 👋, same context as https://github.com/privatenumber/type-flag/pull/52

I'm wondering if this is a change you're open to. It relaxes the restriction on top-level CLI naming to allow spaces within the name. Our use-case is separation of the command hierarchy and individual definitions. The command implementations only parse the args provided to the command using `cleye`, rather than the full process argv slice. There's a different layer that handles the command routing.

The benefit of this change is that we can rely on the built-in `usage` generation in `cleye`, rather than needing to redefine it.  For example, the following:

```ts
cli({
  help: { description: ..., usage: 'my-cli repo test [flags...] <path>' },
  parameters: ['<path>'],
  flags: ...,
}, undefined, args)
```

Can be switched to this:

```ts
cli({
  name: 'my-cli repo test',
  help: { description: ... },
  parameters: ['<path>'],
  flags: ...,
}, undefined, args) // side note - open to an (options, args) overload? 😉 
```

I was about to add a condition that restricts this to only be allowed if the `commands` option is not present, but realized that it might still be useful to allow this at the top level, but keep the restriction within the commands of course.
